### PR TITLE
Add simple notes dashboard

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { use, useState, Suspense } from 'react';
 import { Button } from '@/components/ui/button';
-import { CircleIcon, Home, LogOut } from 'lucide-react';
+import { CircleIcon, Home, LogOut, StickyNote } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -63,6 +63,12 @@ function UserMenu() {
           <Link href="/dashboard" className="flex w-full items-center">
             <Home className="mr-2 h-4 w-4" />
             <span>Dashboard</span>
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer">
+          <Link href="/notes" className="flex w-full items-center">
+            <StickyNote className="mr-2 h-4 w-4" />
+            <span>Notes</span>
           </Link>
         </DropdownMenuItem>
         <form action={handleSignOut} className="w-full">

--- a/app/(dashboard)/notes/[id]/page.tsx
+++ b/app/(dashboard)/notes/[id]/page.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { getNoteById } from '@/lib/db/queries';
+
+export default async function NotePage({ params }: { params: { id: string } }) {
+  const note = await getNoteById(Number(params.id));
+  if (!note) {
+    return <div className="p-4">Note not found.</div>;
+  }
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <Link href="/notes" className="mb-4 inline-block text-sm text-blue-500">
+        &larr; Back to notes
+      </Link>
+      <div className="sticky-note rotate-0">
+        <h1 className="text-xl font-medium mb-2">{note.title}</h1>
+        <p className="whitespace-pre-wrap break-words">{note.content}</p>
+      </div>
+    </section>
+  );
+}

--- a/app/(dashboard)/notes/page.tsx
+++ b/app/(dashboard)/notes/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import useSWR from 'swr';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export default function NotesPage() {
+  const { data: notes, mutate } = useSWR('/api/notes', fetcher);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  async function addNote() {
+    await fetch('/api/notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, content }),
+    });
+    setTitle('');
+    setContent('');
+    mutate();
+  }
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <h1 className="text-lg lg:text-2xl font-medium mb-6">Notes</h1>
+
+      <div className="grid gap-4 mb-8 sm:grid-cols-2 lg:grid-cols-3">
+        {notes?.map((note: any, idx: number) => (
+          <Link
+            key={note.id}
+            href={`/notes/${note.id}`}
+            className={`sticky-note block ${idx % 2 === 0 ? '-rotate-1' : 'rotate-1'}`}
+          >
+            <h2 className="font-medium mb-2">{note.title}</h2>
+            <p className="text-sm whitespace-pre-wrap break-words">
+              {note.content.length > 100 ? note.content.slice(0, 100) + '...' : note.content}
+            </p>
+          </Link>
+        ))}
+      </div>
+
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          await addNote();
+        }}
+        className="max-w-md space-y-4"
+      >
+        <Input
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+        />
+        <Textarea
+          placeholder="Your note..."
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          required
+          className="min-h-[120px]"
+        />
+        <Button type="submit" className="bg-orange-500 hover:bg-orange-600 text-white">
+          Add Note
+        </Button>
+      </form>
+    </section>
+  );
+}

--- a/app/api/notes/[id]/route.ts
+++ b/app/api/notes/[id]/route.ts
@@ -1,0 +1,12 @@
+import { getNoteById } from '@/lib/db/queries';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const note = await getNoteById(Number(params.id));
+  if (!note) {
+    return Response.json({ error: 'Not found' }, { status: 404 });
+  }
+  return Response.json(note);
+}

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server';
+import { getNotesForUser, createNote } from '@/lib/db/queries';
+
+export async function GET() {
+  const notes = await getNotesForUser();
+  return Response.json(notes);
+}
+
+export async function POST(req: NextRequest) {
+  const { title, content } = await req.json();
+  const note = await createNote({ title, content });
+  return Response.json(note, { status: 201 });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -158,9 +158,13 @@
   * {
     @apply border-border;
   }
-  body {
+body {
     @apply bg-background text-foreground;
-  }
+}
+
+.sticky-note {
+  @apply bg-yellow-100 p-4 rounded-md shadow-md break-words;
+}
 }
 
 /*

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -90,6 +90,24 @@ export const invitationsRelations = relations(invitations, ({ one }) => ({
   }),
 }));
 
+export const notes = pgTable('notes', {
+  id: serial('id').primaryKey(),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id),
+  title: varchar('title', { length: 255 }).notNull(),
+  content: text('content').notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});
+
+export const notesRelations = relations(notes, ({ one }) => ({
+  user: one(users, {
+    fields: [notes.userId],
+    references: [users.id],
+  }),
+}));
+
 export const teamMembersRelations = relations(teamMembers, ({ one }) => ({
   user: one(users, {
     fields: [teamMembers.userId],
@@ -122,6 +140,8 @@ export type ActivityLog = typeof activityLogs.$inferSelect;
 export type NewActivityLog = typeof activityLogs.$inferInsert;
 export type Invitation = typeof invitations.$inferSelect;
 export type NewInvitation = typeof invitations.$inferInsert;
+export type Note = typeof notes.$inferSelect;
+export type NewNote = typeof notes.$inferInsert;
 export type TeamDataWithMembers = Team & {
   teamMembers: (TeamMember & {
     user: Pick<User, 'id' | 'name' | 'email'>;


### PR DESCRIPTION
## Summary
- add notes table and db queries
- expose API routes to manage notes
- create sticky-note style dashboard for viewing and adding notes
- link notes from the user menu
- introduce `Textarea` UI component

## Testing
- `pnpm build` *(fails: Failed to fetch `Manrope` from Google Fonts)*